### PR TITLE
Remove `o-load` event.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,5 @@
+## Migration Guide
+
+### Migrating from v1 to v2
+
+The event `o.load` has been removed as it [appears not to be used](https://github.com/Financial-Times/o-autoinit/issues/14). Please contact the Origami team if your project requires the `o.load` event.

--- a/README.md
+++ b/README.md
@@ -3,25 +3,26 @@
 
 Auto initalise Origami components
 
-- [Usage](#usage)
-	- [JavaScript](#javascript)
+- [JavaScript](#javascript)
 - [Contact](#contact)
 - [Licence](#licence)
 
-## Usage
+This component comprises a standard way of firing the `o.DOMContentLoaded` event when the equivalent browser-native event fire, and will fire the Origami events even if the native ones have already been and gone, making this suitable for bundling with components that are loaded asyncronously.
 
-This module comprises a standard way of firing the `o.DOMContentLoaded` and `o.load` events when their equivalent browser-native events fire, and will fire the Origami events even if the native ones have already been and gone, making this suitable for bundling with modules that are loaded asyncronously.
-
-### JavaScript
+## JavaScript
 
 ```javascript
 require('o-autoinit');
 ```
 
-The `autoinit` module must be imported after all modules that bind to the initialisation events.  If it is required more than once, subsequent requires will not have any effect, and the initialisation events may be emitted as early as the first require point.
+The `autoinit` component must be imported after all components that bind to the initialisation events. If it is required more than once, subsequent requires will not have any effect, and the initialisation events may be emitted as early as the first require point.
 
+## Migration
 
----
+State | Major Version | Last Minor Release | Migration guide |
+:---: | :---: | :---: | :---:
+✨ active | 2 | N/A  | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+⚠ maintained | 1 | 1.5 | N/A |
 
 ## Contact
 

--- a/main.js
+++ b/main.js
@@ -8,14 +8,11 @@ function trigger(type) {
 	document.dispatchEvent(new CustomEvent('o.'+type));
 }
 
-window.addEventListener('load', trigger.bind(null, 'load'));
-window.addEventListener('load', trigger.bind(null, 'DOMContentLoaded'));
 document.addEventListener('DOMContentLoaded', trigger.bind(null, 'DOMContentLoaded'));
 
 document.onreadystatechange = function () {
 	if (document.readyState === 'complete') {
 		trigger('DOMContentLoaded');
-		trigger('load');
 	} else if (document.readyState === 'interactive' && !document.attachEvent) {
 		trigger('DOMContentLoaded');
 	}
@@ -23,7 +20,6 @@ document.onreadystatechange = function () {
 
 if (document.readyState === 'complete') {
 	trigger('DOMContentLoaded');
-	trigger('load');
 } else if (document.readyState === 'interactive' && !document.attachEvent) {
 	trigger('DOMContentLoaded');
 }

--- a/origami.json
+++ b/origami.json
@@ -1,5 +1,5 @@
 {
-  "description": "Provides a standard way of firing the 'o.DOMContentLoaded' and 'o.load' events if/when the equivalent browser-native events fire, to auto initialise other components that are in use.",
+  "description": "Provides a standard way of firing the 'o.DOMContentLoaded' events if/when the equivalent browser-native events fire, to auto initialise other components that are in use.",
   "origamiType": "module",
   "origamiCategory": "utilities",
   "origamiVersion": 1,

--- a/test/autoinit.test.js
+++ b/test/autoinit.test.js
@@ -4,27 +4,23 @@ import proclaim from 'proclaim';
 import sinon from 'sinon/pkg/sinon';
 
 describe("o-autoinit", () => {
-	let addEventListenerStub;
 	// autoinit is executed upon being required
 	let autoinit; // eslint-disable-line no-unused-vars
 	let docAddEventListenerStub;
 
 	beforeEach(() => {
-		addEventListenerStub = sinon.stub(window, 'addEventListener');
 		docAddEventListenerStub = sinon.stub(document, 'addEventListener');
 
 		autoinit = require('./../main');
 	});
 
 	afterEach(() => {
-		addEventListenerStub.restore();
 		docAddEventListenerStub.restore();
 	});
 
 
 	it('sets event listeners', () => {
-		proclaim.isTrue(addEventListenerStub.calledTwice);
-		proclaim.isTrue(addEventListenerStub.calledWith('load'));
+		proclaim.isTrue(docAddEventListenerStub.calledWith('DOMContentLoaded'));
 		proclaim.isTrue(docAddEventListenerStub.calledOnce);
 	});
 });


### PR DESCRIPTION
Also add a MIGRATION.md and swap 'module' for 'component' in README.md.

Relates to: https://github.com/Financial-Times/o-autoinit/issues/14