### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/autoinit.test.js
+++ b/test/autoinit.test.js
@@ -1,7 +1,5 @@
 /* eslint-env mocha */
-
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* global proclaim sinon */
 
 describe("o-autoinit", () => {
 	// autoinit is executed upon being required


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.