### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/test/autoinit.test.js
+++ b/test/autoinit.test.js
@@ -3,8 +3,8 @@
 // autoinit is executed upon being imported
 // so we must import a test helper before to
 // count the times o-autoinit events are fired
-import getEventCount from './helpers/event-count';
-import './../main';
+import getEventCount from './helpers/event-count.js';
+import './../main.js';
 
 describe("o-autoinit", () => {
 	it('fires o.DOMContentLoaded only once by the time the page is loaded', (done) => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing